### PR TITLE
Fixed fail report by upgrading Dancer2::Plugin v0.204002.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires "Dancer2::Plugin" => "0";
+requires "Dancer2::Plugin" => "0.204002";
 requires "Font::TTF::Font" => "0";
 requires "Font::TTF::Scripts::Name" => "0";
 requires "List::AllUtils" => "0";


### PR DESCRIPTION
Hi @yanick 

Please review the PR.
Proposed to fix the fail report:
https://www.cpantesters.org/cpan/report/58556dbc-7514-11e8-8bde-a7257f658368

Dancer2::Plugin Changes:

0.204002  2016-12-21 15:40:02-06:00 America/Chicago
 
    [ BUG FIXES ]
    * GH #975: Fix "public_dir" configuration to work, just like
      DANCER_PUBLIC. (Sawyer X)
 
    [ ENHANCEMENTS ]
    * You can now call '$self->find_plugin(...)' within a plugin
      in order to find a plugin, in order to use its DSL in your
      custom plugin. (Sawyer X)

Many Thanks.
Best Regards,
Mohammad S Anwar